### PR TITLE
Add testing for error page's link click

### DIFF
--- a/cypress/e2e/error_handling_spec.cy.js
+++ b/cypress/e2e/error_handling_spec.cy.js
@@ -1,0 +1,57 @@
+describe('Error Handling Page', () => {
+  it('Should select the first movie and show 404 error', () => {
+    cy.intercept(
+      'GET',
+      'https://rancid-tomatillos.herokuapp.com/api/v2/movies',
+      {
+        statusCode: 200,
+        fixture: 'mainSampleData'
+      }
+    ).visit('http://localhost:3000/');
+
+    cy.intercept(
+      'GET',
+      'https://rancid-tomatillos.herokuapp.com/api/v2/movies/436270',
+      { statusCode: 404 }
+    );
+
+    cy.get('[href="/movie/436270"] > .movie-card')
+      .click()
+      .url()
+      .should('eq', 'http://localhost:3000/movie/436270')
+      .get('.error')
+      .should('exist')
+      .get('h2')
+      .should('contain', 'Request failed - 404: Nothing to see here')
+      .get('img')
+      .should('have.attr', 'src');
+
+    cy.get('a')
+      .click()
+      .url()
+      .should('eq', 'http://localhost:3000/')
+      .get('.movie-card')
+      .first()
+      .contains('p', 'Rancid Rating - 4.0 🍅s')
+      .get('.movie-card-image')
+      .first()
+      .should(
+        'have.attr',
+        'src',
+        'https://image.tmdb.org/t/p/original//pFlaoHTZeyNkG83vxsAJiGzfSsa.jpg'
+      )
+      .get('.movie-card')
+      .last()
+      .contains('p', 'Rancid Rating - 7.0 🍅s')
+      .get('.movie-card-image')
+      .last()
+      .should(
+        'have.attr',
+        'src',
+        'https://image.tmdb.org/t/p/original//g4yJTzMtOBUTAR2Qnmj8TYIcFVq.jpg'
+      )
+      .get('.movies-container')
+      .find('.movie-card')
+      .should('have.length', 3);
+  });
+});


### PR DESCRIPTION
What I did: Create Cypress test for clicking SingleMovieCards which shows errors

Did this break anything?

- [x] No
- [ ]  Yes

Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix.

Checklist:

- [x]  If this code needs to be tested, all tests are passing
- [x]  The code runs locally
- [x]  There are comments where clarification/ organization is needed
- [ ]  The code is DRY. If it's not, I tried my best
- [x]  I reviewed my code before pushing

Notes:

## Contributors to this pull request:
@Scotty-Brown 
